### PR TITLE
WIP: utf8 input encoding for signature

### DIFF
--- a/lib/channels/authorizer.js
+++ b/lib/channels/authorizer.js
@@ -50,7 +50,7 @@ _.extend(Authorizer.prototype, {
     authorizeLocal: function(socketId, channelData, callback){
         var channelDataString = channelData? JSON.stringify(channelData) : undefined;
         var stringToSign = _.compact([socketId, this.channel.name, channelDataString]).join(':');
-        var auth = this.key + ':' + crypto.createHmac('sha256', this.config.secret).update(stringToSign).digest('hex');
+        var auth = this.key + ':' + crypto.createHmac('sha256', this.config.secret).update(stringToSign, 'utf8').digest('hex');
         var data = {auth: auth};
         if(channelDataString) data.channel_data = channelDataString;
         callback(false, data);


### PR DESCRIPTION
`createHmac` uses 'binary' input encoding by default if the input is a string, which yields a signature the pusher api rejects.

This pull request fixes the issue by making sure the input encoding is set to utf8.

I'm working on writing tests for the `authorizeLocal` function, hopefully I'll add it to the PR tonight/tomorrow.