### PR TITLE
Add support for agent options

### DIFF
--- a/lib/channels/authorizer.js
+++ b/lib/channels/authorizer.js
@@ -85,7 +85,8 @@ _.extend(Authorizer.prototype, {
             url: this.config.authEndpoint,
             form: postData,
             auth: auth,
-            headers: this.authOptions.headers || {}
+            headers: this.authOptions.headers || {},
+            agentOptions: this.authOptions.agent || {}
         }, function (error, response, body) {
             if (error || response.statusCode != 200) {
                 Pusher.warn('Couldn\'t get auth info from your webapp', response.statusCode);


### PR DESCRIPTION
Allow users to pass in agentOptions when making an auth request to the auth endpoint. I use this to allow my client to do SSL client certificate authentication with my auth server.