### PR TITLE
Fixed logging when there is an error but no response

### DIFF
--- a/lib/channels/authorizer.js
+++ b/lib/channels/authorizer.js
@@ -87,10 +87,13 @@ _.extend(Authorizer.prototype, {
             auth: auth,
             headers: this.authOptions.headers || {}
         }, function (error, response, body) {
-            if (error || response.statusCode != 200) {
+            if (error) {
+                Pusher.warn('Couldn\'t get auth info from your webapp', error.reason);
+                callback(true, 'Error Received: ' + error.reason);
+            } else if(response && response.statusCode != 200) {
                 Pusher.warn('Couldn\'t get auth info from your webapp', response.statusCode);
                 callback(true, response.statusCode);
-            }else{
+            } else {
                 var data, parsed = false;
                 try{
                     data = JSON.parse(body);


### PR DESCRIPTION
Hi, I found when there was a connection error, like a TLS / SSL certificate problem, the library crashed because there was no response, so we got useless logging.

This PR fixes that by handling errors separately from bad responses.