### PR TITLE
Remove `Pusher.instances` tracking.

### DIFF
--- a/lib/pusher.js
+++ b/lib/pusher.js
@@ -11,12 +11,6 @@ var Pusher = function(){
 };
 
 _.extend(Pusher, {
-
-    /**
-     * Keep track of Pusher instances
-     */
-    instances: [],
-
     /**
      * Whether or not to autoconnect new instances
      */
@@ -96,9 +90,6 @@ _.extend(Pusher.prototype, {
         if(Pusher.autoConnect){
             this.connect();
         }
-
-        // Keep track of instances
-        Pusher.instances.push(this);
 
         return this;
     },

--- a/test/pusher.js
+++ b/test/pusher.js
@@ -32,9 +32,8 @@ var expectValidSubscriptions = function(connection, channels){
 
 describe('Pusher', function(){
 
-    var pusher, _instances, _autoConnect, connection;
+    var pusher, _autoConnect, connection;
     beforeEach(function(){
-        _instances = Pusher.instances;
         _autoConnect = Pusher.autoConnect;
 
         Pusher.autoConnect = false;
@@ -51,7 +50,6 @@ describe('Pusher', function(){
     });
 
     afterEach(function(){
-        Pusher.instances = _instances;
         Pusher.autoConnect = _autoConnect;
         Connection.prototype.initialize.restore();
         PublicChannel.prototype.initialize.restore();


### PR DESCRIPTION
Tracking instances would cause Pusher instances to accumulate in memory, retaining them and their affiliated closures for the lifetime of the application, and resulting in a memory leak over time.

The variable was unused within the project itself, but as it is exposed as a public API, this will presumably also require a major version jump.