### PR TITLE
add rejectUnauthorized flag

### DIFF
--- a/lib/channels/authorizer.js
+++ b/lib/channels/authorizer.js
@@ -85,6 +85,7 @@ _.extend(Authorizer.prototype, {
             url: this.config.authEndpoint,
             form: postData,
             auth: auth,
+            rejectUnauthorized: (this.config.rejectUnauthorized  == null ? true : this.config.rejectUnauthorized),
             headers: this.authOptions.headers || {}
         }, function (error, response, body) {
             if (error) {


### PR DESCRIPTION
This is to add the rejectUnauthorized flag in the authorize request. 
In my usage, we connect to a Pusher server in an dev environment. However, when trying to connect, the pusher connection error's out:
`Couldn't get auth info from your webapp Host: XX. is not in the cert's altnames: `
More detail of this issue is found here:
https://github.com/request/request/issues/1777

This update is to allow to connect to an invalid certificate for development.
If not set, `rejectUnauthorized` will be true(which is the default)