### PR TITLE
pusher.disconnect() sometimes leaves an ActivityTimer in the event loop

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -278,6 +278,7 @@ _.extend(Connection.prototype, EventEmitter.prototype, {
     resetActivityCheck: function(){
         var self = this;
         self.clearActivityCheck();
+        if (self.state === 'disconnected') return;
         self.activityCheckTimeout = setTimeout(function(){
             if(self.connection) self.connection.ping();
             self.activityCheckTimeout = setTimeout(function(){


### PR DESCRIPTION
I believe something like this should fix an occasional race condition where an ActivityTimer timeout gets set mid-disconnect, and then Pusher doesn't clear its state out of the event loop on disconnect